### PR TITLE
feat(renderer): add vertex and index buffer abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(spdlog)
 
 # --- The Engine ---
-file(GLOB_RECURSE SOURCES "src/*.cpp" "src/*.c" "src/*.h") 
+file(GLOB_RECURSE SOURCES "src/*.cpp" "src/*.c" "src/*.h" "src/*.hpp") 
 
 add_executable(${PROJECT_NAME} ${SOURCES})
 
@@ -83,6 +83,7 @@ FetchContent_MakeAvailable(googletest)
 add_executable(VoltraTests 
     tests/main_test.cpp 
     tests/EventTest.cpp
+    tests/BufferTest.cpp
 )
 
 

--- a/src/Renderer/Buffer.cpp
+++ b/src/Renderer/Buffer.cpp
@@ -1,0 +1,99 @@
+#include "Buffer.hpp"
+#include <glad/glad.h>
+
+namespace Voltra {
+
+    // ==============================================================================
+    // OpenGLVertexBuffer
+    // ==============================================================================
+
+    class OpenGLVertexBuffer : public VertexBuffer
+    {
+    public:
+        OpenGLVertexBuffer(float* vertices, uint32_t size)
+        {
+            glCreateBuffers(1, &m_RendererID);
+            glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
+            glBufferData(GL_ARRAY_BUFFER, size, vertices, GL_STATIC_DRAW);
+        }
+
+        virtual ~OpenGLVertexBuffer()
+        {
+            glDeleteBuffers(1, &m_RendererID);
+        }
+
+        virtual void Bind() const override
+        {
+            glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
+        }
+
+        virtual void Unbind() const override
+        {
+            glBindBuffer(GL_ARRAY_BUFFER, 0);
+        }
+
+        virtual const BufferLayout& GetLayout() const override { return m_Layout; }
+        virtual void SetLayout(const BufferLayout& layout) override { m_Layout = layout; }
+
+    private:
+        uint32_t m_RendererID;
+        BufferLayout m_Layout;
+    };
+
+    // ==============================================================================
+    // OpenGLIndexBuffer
+    // ==============================================================================
+
+    class OpenGLIndexBuffer : public IndexBuffer
+    {
+    public:
+        OpenGLIndexBuffer(uint32_t* indices, uint32_t count)
+            : m_Count(count)
+        {
+            glCreateBuffers(1, &m_RendererID);
+            
+            // GL_ELEMENT_ARRAY_BUFFER is not valid without an actively bound VAO used in many DSA cases
+            // But since we are binding it immediately to upload data, standard binding is fine.
+            // For Index Buffers, binding to GL_ELEMENT_ARRAY_BUFFER effectively binds it to the current VAO if one is bound.
+            // We should just use GlBufferData with the specific target.
+            
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_RendererID);
+            glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
+        }
+
+        virtual ~OpenGLIndexBuffer()
+        {
+            glDeleteBuffers(1, &m_RendererID);
+        }
+
+        virtual void Bind() const override
+        {
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_RendererID);
+        }
+
+        virtual void Unbind() const override
+        {
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+        }
+
+        virtual uint32_t GetCount() const override { return m_Count; }
+
+    private:
+        uint32_t m_RendererID;
+        uint32_t m_Count;
+    };
+
+    // ==============================================================================
+    // Factory Methods
+    // ==============================================================================
+
+    std::unique_ptr<VertexBuffer> VertexBuffer::Create(float* vertices, uint32_t size)
+    {
+        return std::make_unique<OpenGLVertexBuffer>(vertices, size);
+    }
+
+    std::unique_ptr<IndexBuffer> IndexBuffer::Create(uint32_t* indices, uint32_t count)
+    {
+        return std::make_unique<OpenGLIndexBuffer>(indices, count);
+    }
+}

--- a/src/Renderer/Buffer.hpp
+++ b/src/Renderer/Buffer.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <memory>
+#include <cstdint>
+#include <cassert>
+#include <initializer_list>
+
+namespace Voltra {
+
+    enum class ShaderDataType
+    {
+        None = 0, Float, Float2, Float3, Float4, Mat3, Mat4, Int, Int2, Int3, Int4, Bool
+    };
+
+    static uint32_t ShaderDataTypeSize(ShaderDataType type)
+    {
+        switch (type)
+        {
+            case ShaderDataType::Float:    return 4;
+            case ShaderDataType::Float2:   return 4 * 2;
+            case ShaderDataType::Float3:   return 4 * 3;
+            case ShaderDataType::Float4:   return 4 * 4;
+            case ShaderDataType::Mat3:     return 4 * 3 * 3;
+            case ShaderDataType::Mat4:     return 4 * 4 * 4;
+            case ShaderDataType::Int:      return 4;
+            case ShaderDataType::Int2:     return 4 * 2;
+            case ShaderDataType::Int3:     return 4 * 3;
+            case ShaderDataType::Int4:     return 4 * 4;
+            case ShaderDataType::Bool:     return 1;
+        }
+
+        assert(false && "Unknown ShaderDataType!");
+        return 0;
+    }
+
+    struct BufferElement
+    {
+        std::string Name;
+        ShaderDataType Type;
+        uint32_t Size;
+        size_t Offset;
+        bool Normalized;
+
+        BufferElement() = default;
+
+        BufferElement(ShaderDataType type, const std::string& name, bool normalized = false)
+            : Name(name), Type(type), Size(ShaderDataTypeSize(type)), Offset(0), Normalized(normalized)
+        {
+        }
+
+        uint32_t GetComponentCount() const
+        {
+            switch (Type)
+            {
+                case ShaderDataType::Float:   return 1;
+                case ShaderDataType::Float2:  return 2;
+                case ShaderDataType::Float3:  return 3;
+                case ShaderDataType::Float4:  return 4;
+                case ShaderDataType::Mat3:    return 3 * 3;
+                case ShaderDataType::Mat4:    return 4 * 4;
+                case ShaderDataType::Int:     return 1;
+                case ShaderDataType::Int2:    return 2;
+                case ShaderDataType::Int3:    return 3;
+                case ShaderDataType::Int4:    return 4;
+                case ShaderDataType::Bool:    return 1;
+            }
+
+            assert(false && "Unknown ShaderDataType!");
+            return 0;
+        }
+    };
+
+    class BufferLayout
+    {
+    public:
+        BufferLayout() {}
+
+        BufferLayout(const std::initializer_list<BufferElement>& elements)
+            : m_Elements(elements)
+        {
+            CalculateOffsetsAndStride();
+        }
+
+        inline uint32_t GetStride() const { return m_Stride; }
+        inline const std::vector<BufferElement>& GetElements() const { return m_Elements; }
+
+        std::vector<BufferElement>::iterator begin() { return m_Elements.begin(); }
+        std::vector<BufferElement>::iterator end() { return m_Elements.end(); }
+        std::vector<BufferElement>::const_iterator begin() const { return m_Elements.begin(); }
+        std::vector<BufferElement>::const_iterator end() const { return m_Elements.end(); }
+
+    private:
+        void CalculateOffsetsAndStride()
+        {
+            size_t offset = 0;
+            m_Stride = 0;
+            for (auto& element : m_Elements)
+            {
+                element.Offset = offset;
+                offset += element.Size;
+                m_Stride += element.Size;
+            }
+        }
+
+    private:
+        std::vector<BufferElement> m_Elements;
+        uint32_t m_Stride = 0;
+    };
+
+    class VertexBuffer
+    {
+    public:
+        virtual ~VertexBuffer() = default;
+
+        virtual void Bind() const = 0;
+        virtual void Unbind() const = 0;
+
+        virtual const BufferLayout& GetLayout() const = 0;
+        virtual void SetLayout(const BufferLayout& layout) = 0;
+
+        static std::unique_ptr<VertexBuffer> Create(float* vertices, uint32_t size);
+    };
+
+    class IndexBuffer
+    {
+    public:
+        virtual ~IndexBuffer() = default;
+
+        virtual void Bind() const = 0;
+        virtual void Unbind() const = 0;
+
+        virtual uint32_t GetCount() const = 0;
+
+        static std::unique_ptr<IndexBuffer> Create(uint32_t* indices, uint32_t count);
+    };
+
+}

--- a/tests/BufferTest.cpp
+++ b/tests/BufferTest.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+#include "Renderer/Buffer.hpp"
+
+// Helper to access private members if needed, or just test public API
+// BufferLayout API is public, so we can test directly.
+
+TEST(BufferLayout, ShaderDataTypeSize) {
+    EXPECT_EQ(Voltra::ShaderDataTypeSize(Voltra::ShaderDataType::Float), 4);
+    EXPECT_EQ(Voltra::ShaderDataTypeSize(Voltra::ShaderDataType::Float2), 8);
+    EXPECT_EQ(Voltra::ShaderDataTypeSize(Voltra::ShaderDataType::Float3), 12);
+    EXPECT_EQ(Voltra::ShaderDataTypeSize(Voltra::ShaderDataType::Float4), 16);
+    EXPECT_EQ(Voltra::ShaderDataTypeSize(Voltra::ShaderDataType::Mat3), 36); // 4 * 3 * 3
+    EXPECT_EQ(Voltra::ShaderDataTypeSize(Voltra::ShaderDataType::Mat4), 64); // 4 * 4 * 4
+    EXPECT_EQ(Voltra::ShaderDataTypeSize(Voltra::ShaderDataType::Int), 4);
+    EXPECT_EQ(Voltra::ShaderDataTypeSize(Voltra::ShaderDataType::Bool), 1);
+}
+
+TEST(BufferLayout, ElementComponentCount) {
+    Voltra::BufferElement elForFloat3(Voltra::ShaderDataType::Float3, "Position");
+    EXPECT_EQ(elForFloat3.GetComponentCount(), 3);
+
+    Voltra::BufferElement elForMat4(Voltra::ShaderDataType::Mat4, "ViewProjection");
+    EXPECT_EQ(elForMat4.GetComponentCount(), 16); // 4*4
+    
+    Voltra::BufferElement elForBool(Voltra::ShaderDataType::Bool, "Visible");
+    EXPECT_EQ(elForBool.GetComponentCount(), 1);
+}
+
+TEST(BufferLayout, LayoutStrideAndOffsets) {
+    // Define a layout: Position (Float3), Color (Float4), TexCoord (Float2)
+    Voltra::BufferLayout layout = {
+        { Voltra::ShaderDataType::Float3, "Position" },
+        { Voltra::ShaderDataType::Float4, "Color" },
+        { Voltra::ShaderDataType::Float2, "TexCoord" }
+    };
+
+    const auto& elements = layout.GetElements();
+    ASSERT_EQ(elements.size(), 3);
+
+    // Check sizes and offsets
+    // 1. Position: Size 12, Offset 0
+    EXPECT_EQ(elements[0].Size, 12);
+    EXPECT_EQ(elements[0].Offset, 0);
+
+    // 2. Color: Size 16, Offset 12
+    EXPECT_EQ(elements[1].Size, 16);
+    EXPECT_EQ(elements[1].Offset, 12);
+
+    // 3. TexCoord: Size 8, Offset 12 + 16 = 28
+    EXPECT_EQ(elements[2].Size, 8);
+    EXPECT_EQ(elements[2].Offset, 28);
+
+    // Total Stride should be 28 + 8 = 36
+    EXPECT_EQ(layout.GetStride(), 36);
+}
+
+TEST(BufferLayout, EmptyLayout) {
+    Voltra::BufferLayout layout;
+    EXPECT_EQ(layout.GetStride(), 0);
+    EXPECT_TRUE(layout.GetElements().empty());
+}


### PR DESCRIPTION
- Implemented abstract base classes VertexBuffer and IndexBuffer
- Created BufferLayout system for automatic offset/stride calculation
- Added OpenGL implementations using DSA (glCreateBuffers)
- Supports shader data types: Float, Float2, Float3, Float4, Mat3, Mat4, Int, Bool
- Factory pattern with Create() methods returning std::unique_ptr
- Added unit tests for BufferLayout logic
- Updated CMakeLists.txt to support .hpp files