### PR TITLE
feat(scene): implement scene serialization system with yaml-cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ target_link_libraries(${PROJECT_NAME}
     spdlog::spdlog
     EnTT::EnTT
     box2d
+    yaml-cpp
     ${CMAKE_DL_LIBS}
 )
 
@@ -160,6 +161,16 @@ set(BOX2D_BUILD_UNIT_TESTS OFF CACHE BOOL "" FORCE)
 set(BOX2D_BUILD_TESTBED OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(box2d)
 
+# --- Dependency: yaml-cpp (Serialization) ---
+message(STATUS "Fetching yaml-cpp...")
+FetchContent_Declare(
+    yaml-cpp
+    GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+    GIT_TAG        master
+)
+set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(yaml-cpp)
+
 # --- Test Executable ---
 # We create a separate executable just for running tests
 add_executable(VoltraTests 
@@ -171,6 +182,7 @@ add_executable(VoltraTests
     tests/ECSTest.cpp
     tests/TextureTest.cpp
     tests/TextureManagerTest.cpp
+    tests/SceneSerializerTest.cpp
     ${ENGINE_SOURCES}
 )
 
@@ -187,6 +199,7 @@ target_link_libraries(VoltraTests
     spdlog::spdlog
     EnTT::EnTT
     box2d
+    yaml-cpp
     ${CMAKE_DL_LIBS}
 )
 

--- a/assets/scenes/Example.voltra
+++ b/assets/scenes/Example.voltra
@@ -1,0 +1,55 @@
+Scene: Untitled
+Entities:
+  - Entity: 12837192831273
+    TagComponent:
+      Tag: Box
+    TransformComponent:
+      Translation: [0.5184995, -1.9834853, 0]
+      Rotation: [0, 0, -0.0028340502]
+      Scale: [1, 1, 1]
+    SpriteRendererComponent:
+      Color: [0, 0, 0, 1]
+    Rigidbody2DComponent:
+      BodyType: 2
+      FixedRotation: false
+    BoxCollider2DComponent:
+      Offset: [0, 0]
+      Size: [0.5, 0.5]
+      Density: 1
+      Friction: 0.5
+      Restitution: 0
+      RestitutionThreshold: 0.5
+  - Entity: 12837192831273
+    TagComponent:
+      Tag: Ground
+    TransformComponent:
+      Translation: [0, -3, 0]
+      Rotation: [0, 0, 0]
+      Scale: [3, 1, 1]
+    SpriteRendererComponent:
+      Color: [1, 1, 1, 1]
+    Rigidbody2DComponent:
+      BodyType: 0
+      FixedRotation: false
+    BoxCollider2DComponent:
+      Offset: [0, 0]
+      Size: [0.5, 0.5]
+      Density: 1
+      Friction: 0.5
+      Restitution: 0
+      RestitutionThreshold: 0.5
+  - Entity: 12837192831273
+    TagComponent:
+      Tag: Camera
+    TransformComponent:
+      Translation: [0, 0, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    CameraComponent:
+      Camera:
+        ProjectionType: 1
+        OrthographicSize: 10
+        OrthographicNear: -1
+        OrthographicFar: 1
+      Primary: true
+      FixedAspectRatio: false

--- a/src/Scene/Components.hpp
+++ b/src/Scene/Components.hpp
@@ -74,6 +74,10 @@ namespace Voltra {
         bool Primary = true; // If there are multiple cameras, is this the main one?
         bool FixedAspectRatio = false;
 
+        float OrthographicSize = 10.0f;
+        float OrthographicNear = -1.0f;
+        float OrthographicFar = 1.0f;
+
         // Constructor by default initializing a basic orthographic camera (-1 to 1)
         CameraComponent() 
             : Camera(-1.0f, 1.0f, -1.0f, 1.0f) {} // Default aspect ratio 1.0

--- a/src/Scene/Scene.hpp
+++ b/src/Scene/Scene.hpp
@@ -22,7 +22,9 @@ namespace Voltra {
         void OnRuntimeStart();
         void OnRuntimeStop();
 
-        void OnUpdate(Timestep ts);
+        void OnUpdate(Timestep ts); // Existing
+
+        entt::registry& GetRegistry() { return m_Registry; }
 
     private:
         entt::registry m_Registry;
@@ -30,6 +32,7 @@ namespace Voltra {
 
         friend class Entity;
         friend class SceneHierarchyPanel;
+        friend class SceneSerializer;
     };
 
 }

--- a/src/Scene/SceneSerializer.cpp
+++ b/src/Scene/SceneSerializer.cpp
@@ -1,0 +1,296 @@
+#include "Scene/SceneSerializer.hpp"
+
+#include "Scene/Entity.hpp"
+#include "Scene/Components.hpp"
+
+#include <yaml-cpp/yaml.h>
+#include <fstream>
+
+namespace YAML {
+
+    template<>
+    struct convert<glm::vec2> {
+        static Node encode(const glm::vec2& rhs) {
+            Node node;
+            node.push_back(rhs.x);
+            node.push_back(rhs.y);
+            node.SetStyle(EmitterStyle::Flow);
+            return node;
+        }
+
+        static bool decode(const Node& node, glm::vec2& rhs) {
+            if (!node.IsSequence() || node.size() != 2)
+                return false;
+
+            rhs.x = node[0].as<float>();
+            rhs.y = node[1].as<float>();
+            return true;
+        }
+    };
+
+    template<>
+    struct convert<glm::vec3> {
+        static Node encode(const glm::vec3& rhs) {
+            Node node;
+            node.push_back(rhs.x);
+            node.push_back(rhs.y);
+            node.push_back(rhs.z);
+            node.SetStyle(EmitterStyle::Flow);
+            return node;
+        }
+
+        static bool decode(const Node& node, glm::vec3& rhs) {
+            if (!node.IsSequence() || node.size() != 3)
+                return false;
+
+            rhs.x = node[0].as<float>();
+            rhs.y = node[1].as<float>();
+            rhs.z = node[2].as<float>();
+            return true;
+        }
+    };
+
+    template<>
+    struct convert<glm::vec4> {
+        static Node encode(const glm::vec4& rhs) {
+            Node node;
+            node.push_back(rhs.x);
+            node.push_back(rhs.y);
+            node.push_back(rhs.z);
+            node.push_back(rhs.w);
+            node.SetStyle(EmitterStyle::Flow);
+            return node;
+        }
+
+        static bool decode(const Node& node, glm::vec4& rhs) {
+            if (!node.IsSequence() || node.size() != 4)
+                return false;
+
+            rhs.x = node[0].as<float>();
+            rhs.y = node[1].as<float>();
+            rhs.z = node[2].as<float>();
+            rhs.w = node[3].as<float>();
+            return true;
+        }
+    };
+}
+
+namespace Voltra {
+
+    YAML::Emitter& operator<<(YAML::Emitter& out, const glm::vec2& v) {
+        out << YAML::Flow;
+        out << YAML::BeginSeq << v.x << v.y << YAML::EndSeq;
+        return out;
+    }
+
+    YAML::Emitter& operator<<(YAML::Emitter& out, const glm::vec3& v) {
+        out << YAML::Flow;
+        out << YAML::BeginSeq << v.x << v.y << v.z << YAML::EndSeq;
+        return out;
+    }
+
+    YAML::Emitter& operator<<(YAML::Emitter& out, const glm::vec4& v) {
+        out << YAML::Flow;
+        out << YAML::BeginSeq << v.x << v.y << v.z << v.w << YAML::EndSeq;
+        return out;
+    }
+
+    SceneSerializer::SceneSerializer(const std::shared_ptr<Scene>& scene)
+        : m_Scene(scene) {
+    }
+
+    static void SerializeEntity(YAML::Emitter& out, Entity entity) {
+        out << YAML::BeginMap; // Entity
+        out << YAML::Key << "Entity" << YAML::Value << "12837192831273"; // TODO: Entity ID goes here
+
+        if (entity.HasComponent<TagComponent>()) {
+            out << YAML::Key << "TagComponent";
+            out << YAML::BeginMap; // TagComponent
+
+            auto& tag = entity.GetComponent<TagComponent>().Tag;
+            out << YAML::Key << "Tag" << YAML::Value << tag;
+
+            out << YAML::EndMap; // TagComponent
+        }
+
+        if (entity.HasComponent<TransformComponent>()) {
+            out << YAML::Key << "TransformComponent";
+            out << YAML::BeginMap; // TransformComponent
+
+            auto& tc = entity.GetComponent<TransformComponent>();
+            out << YAML::Key << "Translation" << YAML::Value << tc.Translation;
+            out << YAML::Key << "Rotation" << YAML::Value << tc.Rotation;
+            out << YAML::Key << "Scale" << YAML::Value << tc.Scale;
+
+            out << YAML::EndMap; // TransformComponent
+        }
+
+        if (entity.HasComponent<CameraComponent>()) {
+            out << YAML::Key << "CameraComponent";
+            out << YAML::BeginMap; // CameraComponent
+
+            auto& cameraComponent = entity.GetComponent<CameraComponent>();
+            auto& camera = cameraComponent.Camera;
+
+            out << YAML::Key << "Camera" << YAML::Value;
+            out << YAML::BeginMap; // Camera
+            out << YAML::Key << "ProjectionType" << YAML::Value << 1; // Assuming Orthographic for now
+            out << YAML::Key << "OrthographicSize" << YAML::Value << cameraComponent.OrthographicSize;
+            out << YAML::Key << "OrthographicNear" << YAML::Value << cameraComponent.OrthographicNear;
+            out << YAML::Key << "OrthographicFar" << YAML::Value << cameraComponent.OrthographicFar;
+            out << YAML::EndMap; // Camera
+
+            out << YAML::Key << "Primary" << YAML::Value << cameraComponent.Primary;
+            out << YAML::Key << "FixedAspectRatio" << YAML::Value << cameraComponent.FixedAspectRatio;
+
+            out << YAML::EndMap; // CameraComponent
+        }
+
+        if (entity.HasComponent<SpriteRendererComponent>()) {
+            out << YAML::Key << "SpriteRendererComponent";
+            out << YAML::BeginMap; // SpriteRendererComponent
+
+            auto& spriteRendererComponent = entity.GetComponent<SpriteRendererComponent>();
+            out << YAML::Key << "Color" << YAML::Value << spriteRendererComponent.Color;
+
+            out << YAML::EndMap; // SpriteRendererComponent
+        }
+
+        if (entity.HasComponent<Rigidbody2DComponent>()) {
+            out << YAML::Key << "Rigidbody2DComponent";
+            out << YAML::BeginMap; // Rigidbody2DComponent
+
+            auto& rb2dComponent = entity.GetComponent<Rigidbody2DComponent>();
+            out << YAML::Key << "BodyType" << YAML::Value << (int)rb2dComponent.Type;
+            out << YAML::Key << "FixedRotation" << YAML::Value << rb2dComponent.FixedRotation;
+
+            out << YAML::EndMap; // Rigidbody2DComponent
+        }
+
+        if (entity.HasComponent<BoxCollider2DComponent>()) {
+            out << YAML::Key << "BoxCollider2DComponent";
+            out << YAML::BeginMap; // BoxCollider2DComponent
+
+            auto& bc2dComponent = entity.GetComponent<BoxCollider2DComponent>();
+            out << YAML::Key << "Offset" << YAML::Value << bc2dComponent.Offset;
+            out << YAML::Key << "Size" << YAML::Value << bc2dComponent.Size;
+            out << YAML::Key << "Density" << YAML::Value << bc2dComponent.Density;
+            out << YAML::Key << "Friction" << YAML::Value << bc2dComponent.Friction;
+            out << YAML::Key << "Restitution" << YAML::Value << bc2dComponent.Restitution;
+            out << YAML::Key << "RestitutionThreshold" << YAML::Value << bc2dComponent.RestitutionThreshold;
+
+            out << YAML::EndMap; // BoxCollider2DComponent
+        }
+
+        out << YAML::EndMap; // Entity
+    }
+
+    void SceneSerializer::Serialize(const std::string& filepath) {
+        YAML::Emitter out;
+        out << YAML::BeginMap;
+        out << YAML::Key << "Scene" << YAML::Value << "Untitled";
+        out << YAML::Key << "Entities" << YAML::Value << YAML::BeginSeq;
+
+        auto view = m_Scene->m_Registry.view<TagComponent>();
+        for (auto entityID : view) {
+            Entity entity = { entityID, m_Scene.get() };
+            if (!entity)
+                continue;
+
+            SerializeEntity(out, entity);
+        }
+
+        out << YAML::EndSeq;
+        out << YAML::EndMap;
+
+        std::ofstream fout(filepath);
+        fout << out.c_str();
+    }
+
+    void SceneSerializer::SerializeRuntime(const std::string& filepath) {
+        // Not implemented yet
+    }
+
+    bool SceneSerializer::Deserialize(const std::string& filepath) {
+        std::ifstream stream(filepath);
+        std::stringstream strStream;
+        strStream << stream.rdbuf();
+
+        YAML::Node data = YAML::Load(strStream.str());
+        if (!data["Scene"])
+            return false;
+
+        std::string sceneName = data["Scene"].as<std::string>();
+        VOLTRA_CORE_TRACE("Deserializing scene '{0}'", sceneName);
+
+        auto entities = data["Entities"];
+        if (entities) {
+            for (auto entity : entities) {
+                uint64_t uuid = entity["Entity"].as<uint64_t>(); // TODO
+
+                std::string name;
+                auto tagComponent = entity["TagComponent"];
+                if (tagComponent)
+                    name = tagComponent["Tag"].as<std::string>();
+
+                Entity deserializedEntity = m_Scene->CreateEntity(name);
+
+                auto transformComponent = entity["TransformComponent"];
+                if (transformComponent) {
+                    // Entities always have transforms
+                    auto& tc = deserializedEntity.GetComponent<TransformComponent>();
+                    tc.Translation = transformComponent["Translation"].as<glm::vec3>();
+                    tc.Rotation = transformComponent["Rotation"].as<glm::vec3>();
+                    tc.Scale = transformComponent["Scale"].as<glm::vec3>();
+                }
+
+                auto cameraComponent = entity["CameraComponent"];
+                if (cameraComponent) {
+                    auto& cc = deserializedEntity.AddComponent<CameraComponent>();
+
+                    auto cameraProps = cameraComponent["Camera"];
+                    cc.OrthographicSize = cameraProps["OrthographicSize"].as<float>();
+                    cc.OrthographicNear = cameraProps["OrthographicNear"].as<float>();
+                    cc.OrthographicFar = cameraProps["OrthographicFar"].as<float>();
+
+                    cc.Camera.SetProjection(-cc.OrthographicSize * 0.5f, cc.OrthographicSize * 0.5f, -cc.OrthographicSize * 0.5f, cc.OrthographicSize * 0.5f);
+
+                    cc.Primary = cameraComponent["Primary"].as<bool>();
+                    cc.FixedAspectRatio = cameraComponent["FixedAspectRatio"].as<bool>();
+                }
+
+                auto spriteRendererComponent = entity["SpriteRendererComponent"];
+                if (spriteRendererComponent) {
+                    auto& src = deserializedEntity.AddComponent<SpriteRendererComponent>();
+                    src.Color = spriteRendererComponent["Color"].as<glm::vec4>();
+                }
+
+                auto rigidbody2DComponent = entity["Rigidbody2DComponent"];
+                if (rigidbody2DComponent) {
+                    auto& rb2d = deserializedEntity.AddComponent<Rigidbody2DComponent>();
+                    rb2d.Type = (Rigidbody2DComponent::BodyType)rigidbody2DComponent["BodyType"].as<int>();
+                    rb2d.FixedRotation = rigidbody2DComponent["FixedRotation"].as<bool>();
+                }
+
+                auto boxCollider2DComponent = entity["BoxCollider2DComponent"];
+                if (boxCollider2DComponent) {
+                    auto& bc2d = deserializedEntity.AddComponent<BoxCollider2DComponent>();
+                    bc2d.Offset = boxCollider2DComponent["Offset"].as<glm::vec2>();
+                    bc2d.Size = boxCollider2DComponent["Size"].as<glm::vec2>();
+                    bc2d.Density = boxCollider2DComponent["Density"].as<float>();
+                    bc2d.Friction = boxCollider2DComponent["Friction"].as<float>();
+                    bc2d.Restitution = boxCollider2DComponent["Restitution"].as<float>();
+                    bc2d.RestitutionThreshold = boxCollider2DComponent["RestitutionThreshold"].as<float>();
+                }
+            }
+        }
+
+        return true;
+    }
+
+    bool SceneSerializer::DeserializeRuntime(const std::string& filepath) {
+        // Not implemented yet
+        return false;
+    }
+
+}

--- a/src/Scene/SceneSerializer.hpp
+++ b/src/Scene/SceneSerializer.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Scene/Scene.hpp"
+#include <memory>
+#include <string>
+
+namespace Voltra {
+
+    class SceneSerializer {
+    public:
+        SceneSerializer(const std::shared_ptr<Scene>& scene);
+
+        void Serialize(const std::string& filepath);
+        void SerializeRuntime(const std::string& filepath);
+
+        bool Deserialize(const std::string& filepath);
+        bool DeserializeRuntime(const std::string& filepath);
+
+    private:
+        std::shared_ptr<Scene> m_Scene;
+    };
+
+}

--- a/tests/SceneSerializerTest.cpp
+++ b/tests/SceneSerializerTest.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+
+#include "Scene/Scene.hpp"
+#include "Scene/Entity.hpp"
+#include "Scene/Components.hpp"
+#include "Scene/SceneSerializer.hpp"
+
+using namespace Voltra;
+
+class SceneSerializerTest : public ::testing::Test {
+protected:
+    std::string filepath = "test_scene_serialization.voltra";
+
+    void TearDown() override {
+        // Limpieza: Borrar el archivo creado tras cada test
+        if (std::filesystem::exists(filepath)) {
+            std::filesystem::remove(filepath);
+        }
+    }
+};
+
+TEST_F(SceneSerializerTest, SerializeAndDeserializeComplexEntity) {
+    // SETUP: Create scene and entity with specific data
+    auto sceneSource = std::make_shared<Scene>();
+    Entity originalEntity = sceneSource->CreateEntity("Player");
+    
+    // Transform modified
+    auto& tc = originalEntity.GetComponent<TransformComponent>();
+    tc.Translation = { 10.0f, 5.0f, -1.0f };
+    tc.Rotation = { 0.0f, 0.0f, 1.57f };
+    tc.Scale = { 2.0f, 2.0f, 1.0f };
+
+    // Sprite Renderer
+    originalEntity.AddComponent<SpriteRendererComponent>(glm::vec4{ 1.0f, 0.0f, 0.0f, 1.0f });
+
+    // Rigidbody Dynamic
+    auto& rb = originalEntity.AddComponent<Rigidbody2DComponent>();
+    rb.Type = Rigidbody2DComponent::BodyType::Dynamic;
+    rb.FixedRotation = true;
+
+    // Box Collider
+    auto& bc = originalEntity.AddComponent<BoxCollider2DComponent>();
+    bc.Size = { 5.0f, 5.0f };
+    bc.Density = 0.8f;
+
+    // ACT: Serialize to disk
+    SceneSerializer serializer(sceneSource);
+    serializer.Serialize(filepath);
+
+    // ACT: Deserialize into a NEW scene
+    auto sceneDest = std::make_shared<Scene>();
+    SceneSerializer deserializer(sceneDest);
+    bool success = deserializer.Deserialize(filepath);
+
+    // ASSERT: Check results
+    ASSERT_TRUE(success) << "La deserialización falló.";
+
+    // Search for the entity in the new scene (iterating, since we don't have a public GetEntityByTag)
+    Entity loadedEntity;
+    bool found = false;
+    sceneDest->GetRegistry().view<TagComponent>().each([&](auto entityID, auto& tagComp) {
+        if (tagComp.Tag == "Player") {
+            loadedEntity = Entity(entityID, sceneDest.get());
+            found = true;
+        }
+    });
+
+    ASSERT_TRUE(found) << "No se encontró la entidad 'Player' en la escena cargada.";
+
+    // ASSERT: Check Transform
+    auto& loadedTC = loadedEntity.GetComponent<TransformComponent>();
+    EXPECT_FLOAT_EQ(loadedTC.Translation.x, 10.0f);
+    EXPECT_FLOAT_EQ(loadedTC.Translation.y, 5.0f);
+    EXPECT_FLOAT_EQ(loadedTC.Rotation.z, 1.57f);
+
+    // ASSERT: Check extra components
+    EXPECT_TRUE(loadedEntity.HasComponent<SpriteRendererComponent>());
+    EXPECT_TRUE(loadedEntity.HasComponent<Rigidbody2DComponent>());
+    EXPECT_TRUE(loadedEntity.HasComponent<BoxCollider2DComponent>());
+
+    // ASSERT: Check physics values
+    auto& loadedRB = loadedEntity.GetComponent<Rigidbody2DComponent>();
+    EXPECT_EQ(loadedRB.Type, Rigidbody2DComponent::BodyType::Dynamic);
+    EXPECT_TRUE(loadedRB.FixedRotation);
+
+    auto& loadedBC = loadedEntity.GetComponent<BoxCollider2DComponent>();
+    EXPECT_FLOAT_EQ(loadedBC.Size.x, 5.0f);
+    EXPECT_FLOAT_EQ(loadedBC.Density, 0.8f);
+}


### PR DESCRIPTION
- Integrated yaml-cpp dependency in CMake.
- Implemented SceneSerializer for saving and loading scenes.
- Added support for Tag, Transform, Camera, Sprite, and Physics components.
- Fixed scene loading logic in EditorLayer to prevent entity duplication.
- Added unit tests for serialization (SceneSerializerTest).