### PR TITLE
feat(renderer): implement batch rendering for 2D quads

### DIFF
--- a/src/Renderer/Buffer.cpp
+++ b/src/Renderer/Buffer.cpp
@@ -22,6 +22,17 @@ namespace Voltra {
         }
 
         /**
+         * @brief Constructs a dynamic OpenGLVertexBuffer.
+         * 
+         * @param size Size in bytes.
+         */
+        OpenGLVertexBuffer(uint32_t size) {
+            glCreateBuffers(1, &m_RendererID);
+            glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
+            glBufferData(GL_ARRAY_BUFFER, size, nullptr, GL_DYNAMIC_DRAW);
+        }
+
+        /**
          * @brief Destructor. Deletes the buffer.
          */
         virtual ~OpenGLVertexBuffer() {
@@ -40,6 +51,11 @@ namespace Voltra {
          */
         virtual void Unbind() const override {
             glBindBuffer(GL_ARRAY_BUFFER, 0);
+        }
+
+        virtual void SetData(const void* data, uint32_t size) override {
+            glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
+            glBufferSubData(GL_ARRAY_BUFFER, 0, size, data);
         }
 
         virtual const BufferLayout& GetLayout() const override { return m_Layout; }
@@ -106,6 +122,16 @@ namespace Voltra {
      */
     std::unique_ptr<VertexBuffer> VertexBuffer::Create(float* vertices, uint32_t size) {
         return std::make_unique<OpenGLVertexBuffer>(vertices, size);
+    }
+
+    /**
+     * @brief Factory method to create a dynamic vertex buffer.
+     * 
+     * @param size Size in bytes.
+     * @return Unique ptr to the created VertexBuffer.
+     */
+    std::unique_ptr<VertexBuffer> VertexBuffer::Create(uint32_t size) {
+        return std::make_unique<OpenGLVertexBuffer>(size);
     }
 
     /**

--- a/src/Renderer/Buffer.hpp
+++ b/src/Renderer/Buffer.hpp
@@ -183,6 +183,14 @@ namespace Voltra {
         virtual void SetLayout(const BufferLayout& layout) = 0;
 
         /**
+         * @brief Updates the buffer data.
+         * 
+         * @param data Pointer to the new data.
+         * @param size Size of the data in bytes.
+         */
+        virtual void SetData(const void* data, uint32_t size) = 0;
+
+        /**
          * @brief Creates a VertexBuffer.
          * 
          * @param vertices Pointer to vertex data.
@@ -190,6 +198,14 @@ namespace Voltra {
          * @return Unique pointer to the created buffer.
          */
         static std::unique_ptr<VertexBuffer> Create(float* vertices, uint32_t size);
+
+        /**
+         * @brief Creates a dynamic VertexBuffer.
+         * 
+         * @param size Size of the buffer in bytes.
+         * @return Unique pointer to the created buffer.
+         */
+        static std::unique_ptr<VertexBuffer> Create(uint32_t size);
     };
 
     /**

--- a/src/Renderer/RenderCommand.cpp
+++ b/src/Renderer/RenderCommand.cpp
@@ -27,9 +27,11 @@ namespace Voltra {
          * @brief Issues an OpenGL DrawElements call.
          * 
          * @param vertexArray The VAO to draw.
+         * @param indexCount The number of indices to draw.
          */
-        void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray) override {
-            glDrawElements(GL_TRIANGLES, vertexArray->GetIndexBuffer()->GetCount(), GL_UNSIGNED_INT, nullptr);
+        void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray, uint32_t indexCount = 0) override {
+            uint32_t count = indexCount ? indexCount : vertexArray->GetIndexBuffer()->GetCount();
+            glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, nullptr);
         }
     };
 

--- a/src/Renderer/RenderCommand.hpp
+++ b/src/Renderer/RenderCommand.hpp
@@ -31,9 +31,10 @@ namespace Voltra {
          * @brief Issues an indexed draw call.
          * 
          * @param vertexArray The vertex array containing geometry.
+         * @param indexCount Optional index count to draw.
          */
-        static void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray) {
-            s_RendererAPI->DrawIndexed(vertexArray);
+        static void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray, uint32_t indexCount = 0) {
+            s_RendererAPI->DrawIndexed(vertexArray, indexCount);
         }
 
     private:

--- a/src/Renderer/Renderer2D.cpp
+++ b/src/Renderer/Renderer2D.cpp
@@ -19,10 +19,10 @@ namespace Voltra {
     };
 
     struct Renderer2DData {
-        static const uint32_t MaxQuads = 10000;
-        static const uint32_t MaxVertices = MaxQuads * 4;
-        static const uint32_t MaxIndices = MaxQuads * 6;
-        static const uint32_t MaxTextureSlots = 32; // TODO: RenderCaps
+        static constexpr uint32_t MaxQuads = 10000;
+        static constexpr uint32_t MaxVertices = MaxQuads * 4;
+        static constexpr uint32_t MaxIndices = MaxQuads * 6;
+        static constexpr uint32_t MaxTextureSlots = 32; // TODO: RenderCaps
 
         std::shared_ptr<VertexArray> QuadVertexArray;
         std::shared_ptr<VertexBuffer> QuadVertexBuffer;

--- a/src/Renderer/Renderer2D.cpp
+++ b/src/Renderer/Renderer2D.cpp
@@ -3,68 +3,116 @@
 #include "VertexArray.hpp"
 #include "Shader.hpp"
 #include "RenderCommand.hpp"
+#include "../Core/Log.hpp"
 
 #include <glm/gtc/matrix_transform.hpp>
-#include <memory>
+#include <array>
 
 namespace Voltra {
 
-    /**
-     * @brief Internal storage for Renderer2D data.
-     */
-    struct Renderer2DStorage {
-        std::shared_ptr<VertexArray> QuadVertexArray;
-        std::shared_ptr<Shader> TextureShader;
-        std::shared_ptr<Texture2D> WhiteTexture;
+    struct QuadVertex {
+        glm::vec4 Color;
+        glm::vec3 Position;
+        glm::vec2 TexCoord;
+        float TexIndex;
+        float TilingFactor;
     };
 
-    static Renderer2DStorage* s_Data;
+    struct Renderer2DData {
+        static const uint32_t MaxQuads = 10000;
+        static const uint32_t MaxVertices = MaxQuads * 4;
+        static const uint32_t MaxIndices = MaxQuads * 6;
+        static const uint32_t MaxTextureSlots = 32; // TODO: RenderCaps
 
-    /**
-     * @brief Initializes the 2D renderer.
-     * 
-     * Creates Vertex Arrays, Buffers, default Textures, and Shaders.
-     */
+        std::shared_ptr<VertexArray> QuadVertexArray;
+        std::shared_ptr<VertexBuffer> QuadVertexBuffer;
+        std::shared_ptr<Shader> TextureShader;
+        std::shared_ptr<Texture2D> WhiteTexture;
+
+        uint32_t QuadIndexCount = 0;
+        std::unique_ptr<QuadVertex[]> QuadVertexBufferBase;
+        QuadVertex* QuadVertexBufferPtr = nullptr;
+
+        std::array<std::shared_ptr<Texture2D>, MaxTextureSlots> TextureSlots;
+        uint32_t TextureSlotIndex = 1; // 0 = white texture
+
+        glm::vec4 QuadVertexPositions[4];
+
+        Renderer2D::Statistics Stats;
+    };
+
+    static Renderer2DData s_Data;
+
     void Renderer2D::Init() {
-        s_Data = new Renderer2DStorage();
-        s_Data->QuadVertexArray = VertexArray::Create();
+        s_Data.QuadVertexArray = VertexArray::Create();
 
-        float squareVertices[5 * 4] = {
-            -0.5f, -0.5f, 0.0f, 0.0f, 0.0f,
-             0.5f, -0.5f, 0.0f, 1.0f, 0.0f,
-             0.5f,  0.5f, 0.0f, 1.0f, 1.0f,
-            -0.5f,  0.5f, 0.0f, 0.0f, 1.0f
-        };
-
-        std::shared_ptr<VertexBuffer> squareVB = VertexBuffer::Create(squareVertices, sizeof(squareVertices));
-
-        squareVB->SetLayout({
+        s_Data.QuadVertexBuffer = VertexBuffer::Create(s_Data.MaxVertices * sizeof(QuadVertex));
+        s_Data.QuadVertexBuffer->SetLayout({
+            { ShaderDataType::Float4, "a_Color" },
             { ShaderDataType::Float3, "a_Position" },
-            { ShaderDataType::Float2, "a_TexCoord" }
+            { ShaderDataType::Float2, "a_TexCoord" },
+            { ShaderDataType::Float, "a_TexIndex" },
+            { ShaderDataType::Float, "a_TilingFactor" }
         });
-        s_Data->QuadVertexArray->AddVertexBuffer(squareVB);
+        s_Data.QuadVertexArray->AddVertexBuffer(s_Data.QuadVertexBuffer);
 
-        uint32_t squareIndices[6] = { 0, 1, 2, 2, 3, 0 };
-        std::shared_ptr<IndexBuffer> squareIB = IndexBuffer::Create(squareIndices, sizeof(squareIndices) / sizeof(uint32_t));
-        s_Data->QuadVertexArray->SetIndexBuffer(squareIB);
+        s_Data.QuadVertexBufferBase = std::make_unique<QuadVertex[]>(s_Data.MaxVertices);
 
-        s_Data->WhiteTexture = std::make_shared<Texture2D>(1, 1, TextureFilter::Nearest);
+        uint32_t* quadIndices = new uint32_t[s_Data.MaxIndices];
+        uint32_t offset = 0;
+        for (uint32_t i = 0; i < s_Data.MaxIndices; i += 6) {
+            quadIndices[i + 0] = offset + 0;
+            quadIndices[i + 1] = offset + 1;
+            quadIndices[i + 2] = offset + 2;
+
+            quadIndices[i + 3] = offset + 2;
+            quadIndices[i + 4] = offset + 3;
+            quadIndices[i + 5] = offset + 0;
+
+            offset += 4;
+        }
+
+        std::shared_ptr<IndexBuffer> quadIB = IndexBuffer::Create(quadIndices, s_Data.MaxIndices);
+        s_Data.QuadVertexArray->SetIndexBuffer(quadIB);
+        delete[] quadIndices;
+
+        s_Data.WhiteTexture = std::make_shared<Texture2D>(1, 1, TextureFilter::Nearest);
         uint32_t whiteTextureData = 0xffffffff;
-        s_Data->WhiteTexture->SetData(&whiteTextureData, sizeof(uint32_t));
+        s_Data.WhiteTexture->SetData(&whiteTextureData, sizeof(uint32_t));
+
+        // Validation of Texture Slots
+        int32_t maxTextureSlots = 0;
+        glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &maxTextureSlots);
+        if (maxTextureSlots < (int32_t)s_Data.MaxTextureSlots) {
+            VOLTRA_CORE_WARN("Renderer2D: GPU only supports {0} texture slots, but {1} are required. Visual artifacts may occur.", maxTextureSlots, s_Data.MaxTextureSlots);
+        }
+
+        int32_t samplers[s_Data.MaxTextureSlots];
+        for (uint32_t i = 0; i < s_Data.MaxTextureSlots; i++)
+            samplers[i] = i;
+
         std::string vertexSrc = R"(
             #version 330 core
             
-            layout(location = 0) in vec3 a_Position;
-            layout(location = 1) in vec2 a_TexCoord;
+            layout(location = 0) in vec4 a_Color;
+            layout(location = 1) in vec3 a_Position;
+            layout(location = 2) in vec2 a_TexCoord;
+            layout(location = 3) in float a_TexIndex;
+            layout(location = 4) in float a_TilingFactor;
             
             uniform mat4 u_ViewProjection;
-            uniform mat4 u_Transform;
-
+            
+            out vec4 v_Color;
             out vec2 v_TexCoord;
+            out float v_TexIndex;
+            out float v_TilingFactor;
             
             void main() {
+                v_Color = a_Color;
                 v_TexCoord = a_TexCoord;
-                gl_Position = u_ViewProjection * u_Transform * vec4(a_Position, 1.0);
+                v_TexIndex = a_TexIndex;
+                v_TilingFactor = a_TilingFactor;
+                gl_Position = u_ViewProjection * vec4(a_Position, 1.0);
             }
         )";
 
@@ -73,129 +121,156 @@ namespace Voltra {
             
             layout(location = 0) out vec4 color;
             
+            in vec4 v_Color;
             in vec2 v_TexCoord;
+            in float v_TexIndex;
+            in float v_TilingFactor;
             
-            uniform vec4 u_Color;
-            uniform sampler2D u_Texture;
-            uniform float u_TilingFactor;
+            uniform sampler2D u_Textures[32];
             
             void main() {
-                color = texture(u_Texture, v_TexCoord * u_TilingFactor) * u_Color;
+                color = texture(u_Textures[int(v_TexIndex)], v_TexCoord * v_TilingFactor) * v_Color;
             }
         )";
 
-        s_Data->TextureShader = std::make_shared<Shader>(vertexSrc, fragmentSrc);
-        s_Data->TextureShader->Bind();
-        s_Data->TextureShader->UploadUniformInt("u_Texture", 0);
+        s_Data.TextureShader = std::make_shared<Shader>(vertexSrc, fragmentSrc);
+        s_Data.TextureShader->Bind();
+        s_Data.TextureShader->UploadUniformIntArray("u_Textures", samplers, s_Data.MaxTextureSlots);
+
+        s_Data.TextureSlots[0] = s_Data.WhiteTexture;
+
+        s_Data.QuadVertexPositions[0] = { -0.5f, -0.5f, 0.0f, 1.0f };
+        s_Data.QuadVertexPositions[1] = {  0.5f, -0.5f, 0.0f, 1.0f };
+        s_Data.QuadVertexPositions[2] = {  0.5f,  0.5f, 0.0f, 1.0f };
+        s_Data.QuadVertexPositions[3] = { -0.5f,  0.5f, 0.0f, 1.0f };
     }
 
-    /**
-     * @brief Shuts down the 2D renderer and frees memory.
-     */
     void Renderer2D::Shutdown() {
-        delete s_Data;
+        // s_Data.QuadVertexBufferBase is a unique_ptr, so it deletes automatically.
     }
 
-    /**
-     * @brief Prepares the scene for rendering.
-     * 
-     * Uploads the camera view-projection matrix to the shader.
-     * 
-     * @param camera The scene camera.
-     */
     void Renderer2D::BeginScene(const OrthographicCamera& camera) {
-        s_Data->TextureShader->Bind();
-        s_Data->TextureShader->UploadUniformMat4("u_ViewProjection", camera.GetViewProjectionMatrix());
+        s_Data.TextureShader->Bind();
+        s_Data.TextureShader->UploadUniformMat4("u_ViewProjection", camera.GetViewProjectionMatrix());
+
+        StartBatch();
     }
 
-    /**
-     * @brief Finalizes the scene rendering (flushes batches).
-     */
     void Renderer2D::EndScene() {
+        Flush();
     }
 
-    /**
-     * @brief Draws a colored quad at 2D position.
-     * 
-     * @param position Position X, Y.
-     * @param size Width and Height.
-     * @param color Color.
-     */
+    void Renderer2D::Flush() {
+        if (s_Data.QuadIndexCount == 0)
+            return; // Nothing to draw
+
+        uint32_t dataSize = (uint32_t)((uint8_t*)s_Data.QuadVertexBufferPtr - (uint8_t*)s_Data.QuadVertexBufferBase.get());
+        s_Data.QuadVertexBuffer->SetData(s_Data.QuadVertexBufferBase.get(), dataSize);
+
+        // Bind textures
+        for (uint32_t i = 0; i < s_Data.TextureSlotIndex; i++)
+            s_Data.TextureSlots[i]->Bind(i);
+
+        s_Data.TextureShader->Bind();
+        RenderCommand::DrawIndexed(s_Data.QuadVertexArray, s_Data.QuadIndexCount);
+        s_Data.Stats.DrawCalls++;
+    }
+
+    void Renderer2D::StartBatch() {
+        s_Data.QuadIndexCount = 0;
+        s_Data.QuadVertexBufferPtr = s_Data.QuadVertexBufferBase.get();
+        s_Data.TextureSlotIndex = 1;
+    }
+
+    void Renderer2D::NextBatch() {
+        Flush();
+        StartBatch();
+    }
+
     void Renderer2D::DrawQuad(const glm::vec2& position, const glm::vec2& size, const glm::vec4& color) {
         DrawQuad({ position.x, position.y, 0.0f }, size, color);
     }
 
-    /**
-     * @brief Draws a colored quad at 3D position.
-     * 
-     * @param position Position X, Y, Z.
-     * @param size Width and Height.
-     * @param color Color.
-     */
     void Renderer2D::DrawQuad(const glm::vec3& position, const glm::vec2& size, const glm::vec4& color) {
         glm::mat4 transform = glm::translate(glm::mat4(1.0f), position) * glm::scale(glm::mat4(1.0f), { size.x, size.y, 1.0f });
         DrawQuad(transform, color);
     }
 
-    /**
-     * @brief Draws a colored quad with transform matrix.
-     * 
-     * @param transform Model matrix.
-     * @param color Color.
-     */
     void Renderer2D::DrawQuad(const glm::mat4& transform, const glm::vec4& color) {
-        s_Data->TextureShader->Bind();
-        s_Data->TextureShader->UploadUniformFloat4("u_Color", color);
-        s_Data->TextureShader->UploadUniformMat4("u_Transform", transform);
+        const float textureIndex = 0.0f; // White Texture
+        const float tilingFactor = 1.0f;
+        const glm::vec2 texCoords[] = { { 0.0f, 0.0f }, { 1.0f, 0.0f }, { 1.0f, 1.0f }, { 0.0f, 1.0f } };
 
-        s_Data->WhiteTexture->Bind(0);
-        
-        s_Data->QuadVertexArray->Bind();
-        RenderCommand::DrawIndexed(s_Data->QuadVertexArray);
+        if (s_Data.QuadIndexCount >= Renderer2DData::MaxIndices)
+            NextBatch();
+
+        for (size_t i = 0; i < 4; i++) {
+            s_Data.QuadVertexBufferPtr->Position = transform * s_Data.QuadVertexPositions[i];
+            s_Data.QuadVertexBufferPtr->Color = color;
+            s_Data.QuadVertexBufferPtr->TexCoord = texCoords[i];
+            s_Data.QuadVertexBufferPtr->TexIndex = textureIndex;
+            s_Data.QuadVertexBufferPtr->TilingFactor = tilingFactor;
+            s_Data.QuadVertexBufferPtr++;
+        }
+
+        s_Data.QuadIndexCount += 6;
+        s_Data.Stats.QuadCount++;
     }
 
-    /**
-     * @brief Draws a textured quad at 2D position.
-     * 
-     * @param position Position X, Y.
-     * @param size Width and Height.
-     * @param texture Texture to bind.
-     */
     void Renderer2D::DrawQuad(const glm::vec2& position, const glm::vec2& size, const std::shared_ptr<Texture2D>& texture) {
         DrawQuad({ position.x, position.y, 0.0f }, size, texture);
     }
 
-    /**
-     * @brief Draws a textured quad at 3D position.
-     * 
-     * @param position Position X, Y, Z.
-     * @param size Width and Height.
-     * @param texture Texture to bind.
-     */
     void Renderer2D::DrawQuad(const glm::vec3& position, const glm::vec2& size, const std::shared_ptr<Texture2D>& texture) {
         glm::mat4 transform = glm::translate(glm::mat4(1.0f), position) * glm::scale(glm::mat4(1.0f), { size.x, size.y, 1.0f });
         DrawQuad(transform, texture);
     }
 
-    /**
-     * @brief Draws a textured quad with transform matrix.
-     * 
-     * @param transform Model matrix.
-     * @param texture Texture to bind.
-     */
     void Renderer2D::DrawQuad(const glm::mat4& transform, const std::shared_ptr<Texture2D>& texture, float tilingFactor, const glm::vec4& tintColor) {
-        s_Data->TextureShader->Bind();
-        s_Data->TextureShader->UploadUniformFloat4("u_Color", tintColor);
-        s_Data->TextureShader->UploadUniformFloat("u_TilingFactor", tilingFactor);
-        s_Data->TextureShader->UploadUniformMat4("u_Transform", transform);
+        if (s_Data.QuadIndexCount >= Renderer2DData::MaxIndices)
+            NextBatch();
 
-        if (texture)
-            texture->Bind(0);
-        else
-            s_Data->WhiteTexture->Bind(0);
+        float textureIndex = 0.0f;
+        
+        if (texture) {
+            for (uint32_t i = 1; i < s_Data.TextureSlotIndex; i++) {
+                if (*s_Data.TextureSlots[i] == *texture) {
+                    textureIndex = (float)i;
+                    break;
+                }
+            }
 
-        s_Data->QuadVertexArray->Bind();
-        RenderCommand::DrawIndexed(s_Data->QuadVertexArray);
+            if (textureIndex == 0.0f) {
+                if (s_Data.TextureSlotIndex >= Renderer2DData::MaxTextureSlots)
+                    NextBatch();
+
+                textureIndex = (float)s_Data.TextureSlotIndex;
+                s_Data.TextureSlots[s_Data.TextureSlotIndex] = texture;
+                s_Data.TextureSlotIndex++;
+            }
+        }
+
+        const glm::vec2 texCoords[] = { { 0.0f, 0.0f }, { 1.0f, 0.0f }, { 1.0f, 1.0f }, { 0.0f, 1.0f } };
+
+        for (size_t i = 0; i < 4; i++) {
+            s_Data.QuadVertexBufferPtr->Position = transform * s_Data.QuadVertexPositions[i];
+            s_Data.QuadVertexBufferPtr->Color = tintColor;
+            s_Data.QuadVertexBufferPtr->TexCoord = texCoords[i];
+            s_Data.QuadVertexBufferPtr->TexIndex = textureIndex;
+            s_Data.QuadVertexBufferPtr->TilingFactor = tilingFactor;
+            s_Data.QuadVertexBufferPtr++;
+        }
+
+        s_Data.QuadIndexCount += 6;
+        s_Data.Stats.QuadCount++;
+    }
+
+    void Renderer2D::ResetStats() {
+        memset(&s_Data.Stats, 0, sizeof(Statistics));
+    }
+
+    Renderer2D::Statistics Renderer2D::GetStats() {
+        return s_Data.Stats;
     }
 
 }

--- a/src/Renderer/Renderer2D.hpp
+++ b/src/Renderer/Renderer2D.hpp
@@ -2,6 +2,7 @@
 
 #include "OrthographicCamera.hpp"
 #include "Texture.hpp"
+
 #include <glm/glm.hpp>
 #include <memory>
 
@@ -10,57 +11,97 @@ namespace Voltra {
     /**
      * @brief 2D Rendering System.
      * 
-     * Handles batching (in future) and rendering of 2D primitives like quads.
+     * Handles efficient batch rendering of 2D primitives (quads, sprites, etc.).
+     * All geometry is aggregated into a single dynamic vertex buffer and flushed
+     * in minimal draw calls.
      */
     class Renderer2D {
     public:
         /**
+         * @brief Statistics structure for profiling rendering performance.
+         */
+        struct Statistics {
+            uint32_t DrawCalls = 0;
+            uint32_t QuadCount = 0;
+
+            /**
+             * @brief Gets the total vertex count.
+             * @return Total vertices.
+             */
+            uint32_t GetTotalVertexCount() const { return QuadCount * 4; }
+
+            /**
+             * @brief Gets the total index count.
+             * @return Total indices.
+             */
+            uint32_t GetTotalIndexCount() const { return QuadCount * 6; }
+        };
+
+    public:
+        /**
          * @brief Initializes the 2D renderer.
+         * 
+         * Sets up the vertex array, vertex buffers, shaders, and textures.
+         * allocates memory for the batch renderer.
          */
         static void Init();
 
         /**
          * @brief Shuts down the 2D renderer.
+         * 
+         * Frees all allocated resources and buffers.
          */
         static void Shutdown();
 
         /**
          * @brief Begins a new 2D scene.
          * 
-         * @param camera The orthographic camera.
+         * Resets all internal statistics and batch data, preparing for a new frame.
+         * 
+         * @param camera The orthographic camera used for rendering.
          */
         static void BeginScene(const OrthographicCamera& camera);
 
         /**
          * @brief Ends the current scene.
+         * 
+         * Flushes any remaining geometry to the GPU.
          */
         static void EndScene();
+
+        /**
+         * @brief Flushes the current batch.
+         * 
+         * Sends all accumulated geometry to the GPU and resets the batch.
+         * This is automatically called when the buffer is full or at EndScene.
+         */
+        static void Flush();
 
         // Primitives drawing (Colors)
 
         /**
          * @brief Draws a colored quad.
          * 
-         * @param position 2D Position.
-         * @param size Size (width, height).
-         * @param color RGBA Color.
+         * @param position The 2D position (x, y) of the quad center.
+         * @param size The size (width, height) of the quad.
+         * @param color The RGBA color of the quad.
          */
         static void DrawQuad(const glm::vec2& position, const glm::vec2& size, const glm::vec4& color);
 
         /**
-         * @brief Draws a colored quad at a 3D position (Z-depth).
+         * @brief Draws a colored quad at a specific depth.
          * 
-         * @param position 3D Position.
-         * @param size Size (width, height).
-         * @param color RGBA Color.
+         * @param position The 3D position (x, y, z) of the quad center.
+         * @param size The size (width, height) of the quad.
+         * @param color The RGBA color of the quad.
          */
         static void DrawQuad(const glm::vec3& position, const glm::vec2& size, const glm::vec4& color);
 
         /**
-         * @brief Draws a colored quad with a generic transform.
+         * @brief Draws a colored quad with a generic transform matrix.
          * 
-         * @param transform Transformation matrix.
-         * @param color RGBA Color.
+         * @param transform The transformation matrix (translation * rotation * scale).
+         * @param color The RGBA color of the quad.
          */
         static void DrawQuad(const glm::mat4& transform, const glm::vec4& color);
 
@@ -69,28 +110,57 @@ namespace Voltra {
         /**
          * @brief Draws a textured quad.
          * 
-         * @param position 2D Position.
-         * @param size Size.
-         * @param texture Texture to apply.
+         * @param position The 2D position (x, y) of the quad center.
+         * @param size The size (width, height) of the quad.
+         * @param texture The texture to apply to the quad.
          */
         static void DrawQuad(const glm::vec2& position, const glm::vec2& size, const std::shared_ptr<Texture2D>& texture);
 
         /**
-         * @brief Draws a textured quad at a 3D position.
+         * @brief Draws a textured quad at a specific depth.
          * 
-         * @param position 3D Position.
-         * @param size Size.
-         * @param texture Texture to apply.
+         * @param position The 3D position (x, y, z) of the quad center.
+         * @param size The size (width, height) of the quad.
+         * @param texture The texture to apply to the quad.
          */
         static void DrawQuad(const glm::vec3& position, const glm::vec2& size, const std::shared_ptr<Texture2D>& texture);
 
         /**
-         * @brief Draws a textured quad with a generic transform.
+         * @brief Draws a textured quad with a generic transform matrix.
          * 
-         * @param transform Transformation matrix.
-         * @param texture Texture to apply.
+         * @param transform The transformation matrix.
+         * @param texture The texture to apply.
+         * @param tilingFactor The tiling factor for the texture coordinates (default 1.0).
+         * @param tintColor The color to tint the texture with (default white).
          */
         static void DrawQuad(const glm::mat4& transform, const std::shared_ptr<Texture2D>& texture, float tilingFactor = 1.0f, const glm::vec4& tintColor = glm::vec4(1.0f));
+
+        /**
+         * @brief Resets the internal rendering statistics.
+         */
+        static void ResetStats();
+
+        /**
+         * @brief Gets the current rendering statistics.
+         * 
+         * @return A copy of the statistics structure.
+         */
+        static Statistics GetStats();
+
+    private:
+        /**
+         * @brief Starts a new batch.
+         * 
+         * Resets pointers and indices for the next batch.
+         */
+        static void StartBatch();
+
+        /**
+         * @brief Updates the queue for the next flush.
+         * 
+         * Usually called when texture slots are full or buffer is filled.
+         */
+        static void NextBatch();
     };
 
 }

--- a/src/Renderer/RendererAPI.cpp
+++ b/src/Renderer/RendererAPI.cpp
@@ -30,9 +30,11 @@ namespace Voltra {
          * @brief Draws indexed geometry.
          * 
          * @param vertexArray VAO to use.
+         * @param indexCount Number of indices.
          */
-        void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray) override {
-            glDrawElements(GL_TRIANGLES, vertexArray->GetIndexBuffer()->GetCount(), GL_UNSIGNED_INT, nullptr);
+        void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray, uint32_t indexCount = 0) override {
+            uint32_t count = indexCount ? indexCount : vertexArray->GetIndexBuffer()->GetCount();
+            glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, nullptr);
         }
     };
 }

--- a/src/Renderer/RendererAPI.hpp
+++ b/src/Renderer/RendererAPI.hpp
@@ -42,8 +42,9 @@ namespace Voltra {
          * @brief Performs an indexed draw call.
          * 
          * @param vertexArray The vertex array to render.
+         * @param indexCount Optional index count (0 to use entire IB).
          */
-        virtual void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray) = 0;
+        virtual void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray, uint32_t indexCount = 0) = 0;
 
         /**
          * @brief Gets the current API.

--- a/src/Renderer/Shader.cpp
+++ b/src/Renderer/Shader.cpp
@@ -199,6 +199,17 @@ namespace Voltra {
     }
 
     /**
+     * @brief Uploads an int array uniform.
+     * @param name Uniform name.
+     * @param values values pointer.
+     * @param count element count.
+     */
+    void Shader::UploadUniformIntArray(const std::string& name, int* values, uint32_t count) {
+        GLint location = GetUniformLocation(m_RendererID, name);
+        glUniform1iv(location, count, values);
+    }
+
+    /**
      * @brief Uploads a float uniform.
      * @param name Uniform name.
      * @param value value.

--- a/src/Renderer/Shader.hpp
+++ b/src/Renderer/Shader.hpp
@@ -54,6 +54,15 @@ namespace Voltra {
         void UploadUniformInt(const std::string& name, int value);
 
         /**
+         * @brief Uploads an array of integer uniforms.
+         * 
+         * @param name Uniform name.
+         * @param values Pointer to array of integers.
+         * @param count Number of elements.
+         */
+        void UploadUniformIntArray(const std::string& name, int* values, uint32_t count);
+
+        /**
          * @brief Uploads a float uniform.
          * 
          * @param name Uniform name.

--- a/src/Voltra.hpp
+++ b/src/Voltra.hpp
@@ -16,6 +16,7 @@
 
 // --- Renderer System ---
 #include "Renderer/Renderer.hpp"
+#include "Renderer/Renderer2D.hpp"
 #include "Renderer/RenderCommand.hpp"
 #include "Renderer/Buffer.hpp"
 #include "Renderer/Shader.hpp"


### PR DESCRIPTION
Replaces immediate mode rendering with a batch rendering system supporting up to 10,000 quads per draw call.